### PR TITLE
Improving schema version error message.

### DIFF
--- a/search_api_solr/src/SolrConnector/SolrConnectorPluginBase.php
+++ b/search_api_solr/src/SolrConnector/SolrConnectorPluginBase.php
@@ -418,7 +418,11 @@ abstract class SolrConnectorPluginBase extends ConfigurablePluginBase implements
    * {@inheritdoc}
    */
   public function getSchemaVersion($reset = FALSE) {
-    $parts = explode('-', $this->getSchemaVersionString($reset));
+    $schema_version = $this->getSchemaVersionString($reset);
+    $parts = explode('-', $schema_version);
+    if (!isset($parts[1]))
+      throw new \Exception("Invalid Schema Version string: $schema_version.");
+
     return $parts[1];
   }
 


### PR DESCRIPTION
Added an exception throw when the schema version of the Index server is invalid. This will immediately break the index server if the schema is invalid and avoid spamming the logs with multiple similar error messages.